### PR TITLE
Add support for commonmark 0.15.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.5' ]]; then COMPOSER_FLAGS="--prefer-lowest"; else COMPOSER_FLAGS=""; fi
   - composer self-update
   - if [ "$COMMONMARK_VERSION" != "" ]; then composer require "league/commonmark:${COMMONMARK_VERSION}" --no-update; fi;
-  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
+  - composer update --prefer-source --no-interaction $COMPOSER_FLAGS
 
 script:
   - vendor/bin/phpunit $PHPUNIT_COVERAGE

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,23 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-matrix:
-  include:
-    - php: 5.5
-      env: COMPOSER_FLAGS="--prefer-lowest"
-    - php: 5.6
-    - php: 7.0
-      env: PHPUNIT_COVERAGE="--coverage-clover coverage.clover"
-    - php: hhvm
+php:
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+env:
+  - COMMONMARK_VERSION=0.13.*
+  - COMMONMARK_VERSION=0.14.*
+  - COMMONMARK_VERSION=0.15.*
 
 before_script:
+  - if [[ $TRAVIS_PHP_VERSION = '7.0' ]]; then PHPUNIT_COVERAGE="--coverage-clover=coverage.clover"; else PHPUNIT_COVERAGE=""; fi
+  - if [[ $TRAVIS_PHP_VERSION = '5.5' ]]; then COMPOSER_FLAGS="--prefer-lowest"; else COMPOSER_FLAGS=""; fi
   - composer self-update
-  - composer update --prefer-source --no-interaction $COMPOSER_FLAGS
+  - if [ "$COMMONMARK_VERSION" != "" ]; then composer require "league/commonmark:${COMMONMARK_VERSION}" --no-update; fi;
+  - composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 
 script:
   - vendor/bin/phpunit $PHPUNIT_COVERAGE

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^5.5|^7.0",
-        "league/commonmark": "^0.13.2|^0.14",
+        "league/commonmark": "^0.13.2|^0.14|^0.15",
         "twig/twig": "^1.17|^2.0@dev"
     },
     "require-dev": {

--- a/tests/Functional/AttributesTest.php
+++ b/tests/Functional/AttributesTest.php
@@ -12,7 +12,7 @@
 
 namespace Webuni\CommonMark\TwigRenderer\tests\Functional;
 
-use Webuni\CommonMark\AttributesExtension\tests\functional\LocalDataTest as BaseAttributesTest;
+use Webuni\CommonMark\AttributesExtension\Tests\Functional\LocalDataTest as BaseAttributesTest;
 use Webuni\CommonMark\TwigRenderer\Tests\CommonMarkConverter;
 
 class AttributesTest extends BaseAttributesTest


### PR DESCRIPTION
Also added a full test matrix,

This goes along with webuni/commonmark-table-extension#5.

By the way, what is the goal/advantage of having a twig renderer for commonmark ?
